### PR TITLE
dev: task to create a dotenv file locally

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,9 +1,19 @@
-set positional-arguments
 set dotenv-load
 set export
 
+DEVICE_ID := env_var_or_default("DEVICE_ID", "CI_" + file_name(home_directory()) + "_tedge-container-plugin" )
 IMAGE := env_var_or_default("IMAGE", "debian-systemd")
 IMAGE_SRC := env_var_or_default("IMAGE_SRC", "debian-systemd")
+
+# Initialize a dotenv file for usage with a local debugger
+# WARNING: It will override any previously generated dotenv file
+init-dotenv:
+  @echo "Recreating .env file..."
+  @echo "DEVICE_ID=$DEVICE_ID" > .env
+  @echo "IMAGE=$IMAGE" >> .env
+  @echo "C8Y_BASEURL=$C8Y_BASEURL" >> .env
+  @echo "C8Y_USER=$C8Y_USER" >> .env
+  @echo "C8Y_PASSWORD=$C8Y_PASSWORD" >> .env
 
 # Run linting
 lint:


### PR DESCRIPTION
Create an initial dotenv file based on the users current shell.

Using with go-c8y-cli, it makes it easier to set a valid dotenv file with your c8y credentials.

```sh
# set go-c8y-cli session
set-session

# Write settings to file
just init-dotenv
```