### PR TITLE
feat(container): set restart policy to always

### DIFF
--- a/cli/container/install.go
+++ b/cli/container/install.go
@@ -139,8 +139,7 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 		&containerSDK.HostConfig{
 			PublishAllPorts: true,
 			RestartPolicy: containerSDK.RestartPolicy{
-				Name:              containerSDK.RestartPolicyOnFailure,
-				MaximumRetryCount: 5,
+				Name: containerSDK.RestartPolicyAlways,
 			},
 		},
 		&network.NetworkingConfig{


### PR DESCRIPTION
Set the restart policy to `always` when running a container via the `container` sm-plugin