### PR TITLE
fix: add delay before update container status

### DIFF
--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -78,6 +78,16 @@ Manual container creation/deletion
     Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    It works!
     Cumulocity.Should Have Services    name=manualapp1    service_type=container    status=up
 
+    # Pause
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker pause manualapp1;
+    Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Should Have Services    name=manualapp1    service_type=container    status=down
+
+    # Unpause
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker unpause manualapp1;
+    Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Should Have Services    name=manualapp1    service_type=container    status=up
+
     # Uninstall
     ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker rm manualapp1 --force
     Operation Should Be SUCCESSFUL    ${operation}


### PR DESCRIPTION
It seems that the container engine event can occur before the container status has been updated which leads to an out-dated container status being shown in the UI, though it seems that his only occurs "sometimes". Additional logging has been added to help debug the situation should it occur again.